### PR TITLE
corrected api ulr for getting history covid data for kenya

### DIFF
--- a/covidApi.php
+++ b/covidApi.php
@@ -3,9 +3,11 @@
 // get history covid data
 function getHistoricalData(){
 
-    $history_url = "https://disease.sh/v3/covid-19/historical/all?country=Kenya&lastdays=all";
+    $history_url = "https://disease.sh/v3/covid-19/historical/kenya?&lastdays=all";
 
     $covid_history = getData($history_url);
+
+    $covid_history = $covid_history["timeline"];
 
     return $covid_history;
 


### PR DESCRIPTION
The api previously used was returning cumulative history data for all countries.